### PR TITLE
Fixed two bugs

### DIFF
--- a/00. DynamicProgramming/ConsumptionSavingModel.py
+++ b/00. DynamicProgramming/ConsumptionSavingModel.py
@@ -346,8 +346,11 @@ class ConsumptionSavingModelClass(ModelClass):
         m_plus = (par.R/fac)*a + xi            
 
         # c. continuation value
-        inv_v_plus = np.zeros(m_plus.size)
-        linear_interp.interp_1d_vec(sol.m[t+1,:],sol.inv_v[t+1,:],m_plus,inv_v_plus)
+        if still_working_next_period:
+            inv_v_plus = np.zeros(m_plus.size)
+            linear_interp.interp_1d_vec(sol.m[t+1,:],sol.inv_v[t+1,:],m_plus,inv_v_plus)
+        else:
+            inv_v_plus = linear_interp.interp_1d(sol.m[t+1,:],sol.inv_v[t+1,:],m_plus)
         v_plus = 1/inv_v_plus
         
         # d. value-of-choice
@@ -539,3 +542,5 @@ def simulate_time_loop(par,sol,sim):
                     p[i,t+1] = np.log(par.G) + np.log(par.L[t]) + p[i,t] + np.log(sim.psi[i,t+1])   
                     if sim.xi[i,t+1] > 0:
                         y[i,t+1] = p[i,t+1] + np.log(sim.xi[i,t+1])
+                    else:
+                        y[i,t+1] = -np.inf


### PR DESCRIPTION
I have fixed two bugs in the model in the folder "00. DynamicProgramming". The two bugs are as follows:
- **Model cannot be solved with VFI if there is a lifecycle.**
    - **How to reproduce:** Run the last cell in "00. DynamicProgramming/03. A Full Blown Consumption Model" with `par={'solmethod':'vfi'}`
    - **Explanation:** We should interpolate a scalar and not a vector in retirement
    - **Fix:** I have added an if statement to use the correct interpolater
- **Income is not set to zero if xi = 0.**
    - **How to reproduce:** Simulate the model in "00. DynamicProgramming/03. A Full Blown Consumption Model" and run `np.count_nonzero(model.sim.Y==0)` to see that there are no zero income realizations
    - **Explanation:** If xi = 0, income should also be zero (Y = xi * P). In the code currently, y = 0 if xi = 0, which implies that income is Y = exp(y) = exp(0) = 1 instead of 0.
    - **Fix:** Zero income can be obtained by setting y to minus infinity, as Y = exp(-infinity) = 0. I have added an if statement to handle this. This can probably be handled in a better way.